### PR TITLE
Refactor and enhance Catallaxy model components

### DIFF
--- a/src/pricing.jl
+++ b/src/pricing.jl
@@ -71,6 +71,15 @@ function price_american_mc(opt::OptionContract, state::MarketState, config::SimC
     dt = 1.0/252
     nsteps = Int(round(T/dt))
 
+    # Handle very short maturities (less than one time step)
+    if nsteps == 0
+        if opt.is_call
+            return max(0.0, S0 - K)
+        else # Put
+            return max(0.0, K - S0)
+        end
+    end
+
     # Simulate stock price paths
     S_paths = zeros(nsteps + 1, npaths)
     S_paths[1, :] .= S0


### PR DESCRIPTION
This commit incorporates a series of fixes, robustness improvements, and feature enhancements to the Catallaxy agent-based model:

Key Changes:

- Test Suite:
    - Corrected SimConfig and MarketState constructor usage in tests.
    - Updated run_simulation call and return type handling in tests.
    - Added basic unit tests for core types (Price, OrderBook) and market mechanics (order matching in update_orderbook).

- Core Model & Simulation:
    - Entrepreneur initialization now uses keyword arguments for robustness.
    - LSMC option pricing (price_american_mc) now gracefully handles very short maturities by returning intrinsic value, preventing errors.
    - Agent volatility estimation fallback (for NaN results) now uses market state volatility instead of 0.0, and redundant volatility calculations were removed.
    - Standardized asset key usage by replacing hardcoded "STOCK" with dynamic keys (typically opt.underlying), improving flexibility for different underlying assets.
    - Ensured consistent risk-free rate usage in BS delta calculation by using config.risk_premium.

- Agent Logic:
    - Implemented arbitrage logic for call options for the Arbitrageur agent, complementing the existing put logic.

- Documentation & Clarity:
    - Improved comments in market.jl to clearly document limitations of the current order aggregation mechanism and its impact on cost attribution.
    - Reviewed and confirmed plotting layout in the main run script.

These changes improve the model's stability, correctness, test coverage, and flexibility, while also enhancing agent capabilities and code clarity.